### PR TITLE
fix: add push trigger to CI workflow

### DIFF
--- a/.github/workflows/package-builder.yml
+++ b/.github/workflows/package-builder.yml
@@ -3,6 +3,8 @@ name: package-builder
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Add push trigger for main branch to ensure CI runs after merging PRs
- Previously CI only ran on pull requests and manual dispatch
- Now CI will run on both PR creation/updates and merges to main