### PR TITLE
feat: add GitHub Actions workflow for package externalization

### DIFF
--- a/.github/workflows/externalize-package.yml
+++ b/.github/workflows/externalize-package.yml
@@ -1,0 +1,171 @@
+name: Externalize Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_path:
+        description: 'Package path (e.g., packages/svg-editor)'
+        required: true
+        type: string
+      new_repo_name:
+        description: 'New repository name (e.g., tiny-svg-editor)'
+        required: true
+        type: string
+      visibility:
+        description: 'Repository visibility'
+        required: true
+        type: choice
+        options:
+          - public
+          - private
+        default: public
+      scoped_name:
+        description: 'NPM package name (e.g., tiny-svg-editor or @bpm/tiny-svg-editor)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run (preview changes without creating repo)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  externalize:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate package exists
+        run: |
+          if [ ! -d "${{ inputs.package_path }}" ]; then
+            echo "❌ Error: Package path '${{ inputs.package_path }}' does not exist"
+            exit 1
+          fi
+          if [ ! -f "${{ inputs.package_path }}/package.json" ]; then
+            echo "❌ Error: No package.json found in '${{ inputs.package_path }}'"
+            exit 1
+          fi
+          echo "✅ Package validation passed"
+
+      - name: Setup GitHub CLI
+        run: |
+          # GitHub CLI is pre-installed on GitHub Actions runners
+          gh --version
+          
+      - name: Configure GitHub CLI authentication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GitHub CLI will use GITHUB_TOKEN automatically
+          gh auth status
+
+      - name: Run externalization script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Build the command
+          CMD="npx tsx scripts/pb-externalize-copy.ts"
+          CMD="$CMD pkgPath=${{ inputs.package_path }}"
+          CMD="$CMD newRepo=${{ inputs.new_repo_name }}"
+          CMD="$CMD org=${{ github.repository_owner }}"
+          CMD="$CMD visibility=${{ inputs.visibility }}"
+          
+          # Add optional scoped name if provided
+          if [ -n "${{ inputs.scoped_name }}" ]; then
+            CMD="$CMD scopeNameInPkgJson=${{ inputs.scoped_name }}"
+          fi
+          
+          # Add dry run flag if enabled
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            CMD="$CMD dryRun=true"
+            echo "🔍 Running in DRY RUN mode - no changes will be made"
+          fi
+          
+          echo "Executing: $CMD"
+          eval $CMD
+
+      - name: Generate summary
+        if: always()
+        run: |
+          echo "## 📦 Package Externalization Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** \`${{ inputs.package_path }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**New Repository:** \`${{ github.repository_owner }}/${{ inputs.new_repo_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Visibility:** \`${{ inputs.visibility }}\`" >> $GITHUB_STEP_SUMMARY
+          
+          if [ -n "${{ inputs.scoped_name }}" ]; then
+            echo "**NPM Package Name:** \`${{ inputs.scoped_name }}\`" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **This was a DRY RUN** - no actual changes were made" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ✅ Repository Created" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "🔗 **Repository URL:** https://github.com/${{ github.repository_owner }}/${{ inputs.new_repo_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "1. Visit the new repository: https://github.com/${{ github.repository_owner }}/${{ inputs.new_repo_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "2. Verify the GitHub Actions workflow is present in \`.github/workflows/release.yml\`" >> $GITHUB_STEP_SUMMARY
+            echo "3. Check that NPM_TOKEN secret was set (if NPM_TOKEN was available)" >> $GITHUB_STEP_SUMMARY
+            echo "4. To publish a release:" >> $GITHUB_STEP_SUMMARY
+            echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "   cd /path/to/${{ inputs.new_repo_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "   npm version patch  # or minor, major" >> $GITHUB_STEP_SUMMARY
+            echo "   git push --follow-tags" >> $GITHUB_STEP_SUMMARY
+            echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Comment on commit (if not dry run)
+        if: ${{ !inputs.dry_run && github.event_name == 'workflow_dispatch' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const repoUrl = `https://github.com/${{ github.repository_owner }}/${{ inputs.new_repo_name }}`;
+            const message = `## 📦 Package Externalized Successfully
+            
+            **Package:** \`${{ inputs.package_path }}\`
+            **New Repository:** [${repoUrl}](${repoUrl})
+            **Visibility:** \`${{ inputs.visibility }}\`
+            
+            The package has been externalized to its own repository with:
+            - ✅ All source files copied
+            - ✅ GitHub Actions workflow for npm publishing
+            - ✅ Updated package.json with repository info
+            - ✅ NPM_TOKEN secret configured (if available)
+            
+            ### Next Steps
+            
+            1. Visit the new repository: ${repoUrl}
+            2. Create a release:
+               \`\`\`bash
+               npm version patch && git push --follow-tags
+               \`\`\`
+            `;
+            
+            // Create a comment on the latest commit
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: message
+            });
+

--- a/README.md
+++ b/README.md
@@ -378,55 +378,55 @@ Run with `tsx smoke.ts` (or `node --loader ts-node/esm`), exit non-zero on failu
 
 ## 9) Package Externalization
 
-Once a package is mature and ready for independent distribution, you can externalize it to its own GitHub repository using the externalization script.
+Once a package is mature and ready for independent distribution, you can externalize it to its own GitHub repository.
+
+### Quick Start: Using GitHub Actions (Recommended)
+
+The easiest way to externalize a package is through the GitHub Actions workflow:
+
+1. Go to **Actions** tab in your repository
+2. Select **Externalize Package** workflow
+3. Click **Run workflow**
+4. Fill in the parameters:
+   - Package path: `packages/svg-editor`
+   - New repository name: `tiny-svg-editor`
+   - Visibility: `public`
+   - NPM package name: `tiny-svg-editor` (optional)
+   - Dry run: Check to preview first
+5. Click **Run workflow**
+
+See [docs/EXTERNALIZATION.md](docs/EXTERNALIZATION.md) for detailed documentation.
 
 ### Prerequisites
 
-1. **GitHub CLI installed and authenticated**:
-   ```bash
-   gh auth login   # choose GitHub.com, HTTPS, paste token
-   ```
+1. **`NPM_TOKEN` secret**: Required for npm publishing
+   - Get token from: https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+   - Add to repository secrets: Settings → Secrets → Actions → New repository secret
 
-2. **Required token scopes**: `repo`, `workflow`
+2. **`GITHUB_TOKEN`**: Automatically provided by GitHub Actions
 
-3. **NPM_TOKEN available**: Set as environment variable for npm publish permissions
+### Alternative: Command Line Usage
 
-### Usage Examples
+If you prefer to run the script directly (requires GitHub CLI):
 
 **Basic externalization**:
 ```bash
-node scripts/pb-externalize-copy.ts \
+npx tsx scripts/pb-externalize-copy.ts \
   pkgPath=packages/svg-editor \
   newRepo=tiny-svg-editor \
   org=your-github-org
 ```
 
-**With custom package name**:
-```bash
-node scripts/pb-externalize-copy.ts \
-  pkgPath=packages/svg-editor \
-  newRepo=tiny-svg-editor \
-  org=your-github-org \
-  scopeNameInPkgJson=@bpm/tiny-svg-editor
-```
-
-**Private repository**:
-```bash
-node scripts/pb-externalize-copy.ts \
-  pkgPath=packages/svg-editor \
-  newRepo=tiny-svg-editor \
-  org=your-github-org \
-  visibility=private
-```
-
 **Dry run (preview changes)**:
 ```bash
-node scripts/pb-externalize-copy.ts \
+npx tsx scripts/pb-externalize-copy.ts \
   pkgPath=packages/svg-editor \
   newRepo=tiny-svg-editor \
   org=your-github-org \
   dryRun=true
 ```
+
+For more examples and troubleshooting, see [docs/EXTERNALIZATION.md](docs/EXTERNALIZATION.md).
 
 ### What the script does
 

--- a/docs/EXTERNALIZATION.md
+++ b/docs/EXTERNALIZATION.md
@@ -1,0 +1,293 @@
+# Package Externalization Guide
+
+This guide explains how to externalize packages from the monorepo to independent GitHub repositories using the automated workflow.
+
+## Overview
+
+The externalization process creates a new GitHub repository and copies your package content with all necessary configuration for independent publishing to npm.
+
+## Prerequisites
+
+### Required Secrets
+
+The following secrets must be configured in your repository settings:
+
+1. **`GITHUB_TOKEN`** (automatically provided by GitHub Actions)
+   - Used to create repositories and set secrets
+   - No manual configuration needed
+
+2. **`NPM_TOKEN`** (must be manually configured)
+   - Required for npm publishing in the new repository
+   - Get your token from: https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+   - Add it to repository secrets: Settings → Secrets and variables → Actions → New repository secret
+
+### Token Permissions
+
+The `GITHUB_TOKEN` needs the following permissions:
+- `repo` - Full control of repositories
+- `workflow` - Update GitHub Action workflows
+
+For organization repositories, ensure the token has organization access.
+
+## Using the GitHub Actions Workflow
+
+### Method 1: Via GitHub UI (Recommended)
+
+1. Go to your repository on GitHub
+2. Click on **Actions** tab
+3. Select **Externalize Package** workflow from the left sidebar
+4. Click **Run workflow** button
+5. Fill in the required parameters:
+   - **Package path**: `packages/svg-editor`
+   - **New repository name**: `tiny-svg-editor`
+   - **Visibility**: `public` or `private`
+   - **NPM package name** (optional): `tiny-svg-editor` or `@bpm/tiny-svg-editor`
+   - **Dry run**: Check this to preview without making changes
+6. Click **Run workflow**
+
+### Method 2: Via GitHub CLI
+
+```bash
+gh workflow run externalize-package.yml \
+  -f package_path=packages/svg-editor \
+  -f new_repo_name=tiny-svg-editor \
+  -f visibility=public \
+  -f scoped_name=tiny-svg-editor \
+  -f dry_run=false
+```
+
+### Method 3: Via API
+
+```bash
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  https://api.github.com/repos/OWNER/REPO/actions/workflows/externalize-package.yml/dispatches \
+  -d '{
+    "ref": "main",
+    "inputs": {
+      "package_path": "packages/svg-editor",
+      "new_repo_name": "tiny-svg-editor",
+      "visibility": "public",
+      "scoped_name": "tiny-svg-editor",
+      "dry_run": "false"
+    }
+  }'
+```
+
+## Workflow Parameters
+
+### Required Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `package_path` | Path to the package in the monorepo | `packages/svg-editor` |
+| `new_repo_name` | Name for the new repository | `tiny-svg-editor` |
+| `visibility` | Repository visibility (`public` or `private`) | `public` |
+
+### Optional Parameters
+
+| Parameter | Description | Example | Default |
+|-----------|-------------|---------|---------|
+| `scoped_name` | NPM package name (if different from repo name) | `@bpm/tiny-svg-editor` | Same as `new_repo_name` |
+| `dry_run` | Preview changes without creating repository | `true` | `false` |
+
+## What the Workflow Does
+
+1. **Validates** the package exists and has a valid `package.json`
+2. **Authenticates** with GitHub using the provided token
+3. **Creates** a new GitHub repository (if it doesn't exist)
+4. **Copies** all package files to the new repository
+5. **Generates** `.github/workflows/release.yml` for automated npm publishing
+6. **Updates** `package.json` with:
+   - Repository URL
+   - Publish configuration
+   - Release script
+7. **Creates** a `README.md` if one doesn't exist
+8. **Sets** `NPM_TOKEN` secret on the new repository
+9. **Pushes** all changes to the new repository
+10. **Reports** results in the workflow summary
+
+## Example: Externalizing svg-editor
+
+### Dry Run (Preview)
+
+First, run a dry run to see what will happen:
+
+```bash
+# Via GitHub UI
+Actions → Externalize Package → Run workflow
+- package_path: packages/svg-editor
+- new_repo_name: tiny-svg-editor
+- visibility: public
+- scoped_name: tiny-svg-editor
+- dry_run: ✓ (checked)
+```
+
+Review the output to ensure everything looks correct.
+
+### Actual Externalization
+
+Once you're satisfied with the dry run:
+
+```bash
+# Via GitHub UI
+Actions → Externalize Package → Run workflow
+- package_path: packages/svg-editor
+- new_repo_name: tiny-svg-editor
+- visibility: public
+- scoped_name: tiny-svg-editor
+- dry_run: ☐ (unchecked)
+```
+
+### Verify the New Repository
+
+After the workflow completes:
+
+1. Visit: `https://github.com/YOUR_ORG/tiny-svg-editor`
+2. Check that all files are present
+3. Verify `.github/workflows/release.yml` exists
+4. Confirm `package.json` has correct repository URL
+5. Check that `NPM_TOKEN` secret is set (Settings → Secrets)
+
+## Publishing Releases
+
+Once the repository is created, you can publish releases:
+
+```bash
+# Clone the new repository
+git clone https://github.com/YOUR_ORG/tiny-svg-editor.git
+cd tiny-svg-editor
+
+# Make any final adjustments
+# ...
+
+# Create and push a release
+npm version patch  # or minor, major
+git push --follow-tags
+```
+
+The GitHub Actions workflow will automatically:
+- Run tests (if present)
+- Build the package (if build script exists)
+- Publish to npm with provenance
+
+## Troubleshooting
+
+### Error: "Package path does not exist"
+
+**Cause**: The specified package path is incorrect or doesn't exist.
+
+**Solution**: Verify the path is correct relative to the repository root:
+```bash
+ls -la packages/svg-editor  # Should show package contents
+```
+
+### Error: "No package.json found"
+
+**Cause**: The package directory doesn't contain a `package.json` file.
+
+**Solution**: Ensure your package has a valid `package.json`:
+```bash
+cat packages/svg-editor/package.json
+```
+
+### Error: "GitHub CLI authentication failed"
+
+**Cause**: The `GITHUB_TOKEN` doesn't have sufficient permissions.
+
+**Solution**: 
+1. Check workflow permissions: Settings → Actions → General → Workflow permissions
+2. Ensure "Read and write permissions" is selected
+3. Re-run the workflow
+
+### Error: "Failed to set NPM_TOKEN secret"
+
+**Cause**: The `NPM_TOKEN` secret is not configured in the source repository.
+
+**Solution**:
+1. Get your npm token: https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+2. Add to repository: Settings → Secrets and variables → Actions → New repository secret
+3. Name: `NPM_TOKEN`
+4. Value: Your npm token
+
+**Note**: You can also set the secret manually in the new repository after creation.
+
+### Warning: "NPM_TOKEN not found"
+
+**Cause**: The `NPM_TOKEN` secret is not set.
+
+**Impact**: The new repository won't be able to publish to npm automatically.
+
+**Solution**: Manually set the secret in the new repository:
+```bash
+gh secret set NPM_TOKEN -R YOUR_ORG/tiny-svg-editor --body "YOUR_NPM_TOKEN"
+```
+
+## Advanced Usage
+
+### Custom Package Names
+
+If you want the npm package name to differ from the repository name:
+
+```bash
+# Repository: tiny-svg-editor
+# NPM Package: @bpm/tiny-svg-editor
+
+Actions → Externalize Package → Run workflow
+- package_path: packages/svg-editor
+- new_repo_name: tiny-svg-editor
+- visibility: public
+- scoped_name: @bpm/tiny-svg-editor  # ← Custom npm name
+```
+
+### Private Repositories
+
+For private packages:
+
+```bash
+Actions → Externalize Package → Run workflow
+- package_path: packages/internal-utils
+- new_repo_name: internal-utils
+- visibility: private  # ← Private repository
+- scoped_name: @bpm/internal-utils
+```
+
+**Note**: Private npm packages require a paid npm account.
+
+### Batch Externalization
+
+To externalize multiple packages, run the workflow multiple times with different parameters, or create a script:
+
+```bash
+#!/bin/bash
+packages=("svg-editor" "dom-utils" "event-bus")
+
+for pkg in "${packages[@]}"; do
+  gh workflow run externalize-package.yml \
+    -f package_path="packages/$pkg" \
+    -f new_repo_name="$pkg" \
+    -f visibility=public \
+    -f scoped_name="$pkg"
+  
+  # Wait a bit between runs to avoid rate limits
+  sleep 5
+done
+```
+
+## Best Practices
+
+1. **Always run a dry run first** to preview changes
+2. **Verify package.json** is complete before externalizing
+3. **Ensure tests pass** in the monorepo before externalizing
+4. **Document the package** with a good README
+5. **Set up NPM_TOKEN** before externalizing for seamless publishing
+6. **Use semantic versioning** for releases
+7. **Keep a changelog** in the new repository
+
+## See Also
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [npm Publishing Guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry)
+- [Semantic Versioning](https://semver.org/)
+

--- a/github-issue-draft.md
+++ b/github-issue-draft.md
@@ -1,0 +1,144 @@
+# Implement OpenAI Integration for LLM-Driven Pipeline
+
+## Summary
+Replace the current placeholder LLM steps in the package-builder pipeline with actual OpenAI API integration to enable fully automated package generation from feature requests.
+
+## Problem
+Currently, the package-builder has a well-designed architecture for an "LLM-Driven Pipeline" but uses placeholder echo statements instead of actual LLM calls. The 5 agent system (Planner, Implementer, Tester, Packager, Verifier) exists only as prompt templates without implementation.
+
+## Proposed Solution
+Integrate OpenAI's API to power the 5-agent pipeline using the existing prompt templates in the `agents/` folder.
+
+## Implementation Tasks
+
+### 1. Core Infrastructure
+- [ ] Add OpenAI SDK dependency (`openai` package)
+- [ ] Create shared LLM client utility (`src/llm-client.ts`)
+- [ ] Add environment variable validation for `OPENAI_API_KEY`
+- [ ] Configure model selection (GPT-4, GPT-3.5-turbo, etc.)
+
+### 2. Agent Implementation
+Replace placeholder scripts with actual LLM-powered implementations:
+
+#### Planner Agent (`scripts/pb-plan.ts`)
+- [ ] Read feature request input (name, description, requirements)
+- [ ] Use `agents/planner.prompt.md` template
+- [ ] Call OpenAI API to generate package specification JSON
+- [ ] Validate and save plan output
+
+#### Implementer Agent (`scripts/pb-implement.ts`)
+- [ ] Read planner JSON output
+- [ ] Use `agents/implementer.prompt.md` template
+- [ ] Generate TypeScript code, tests, and documentation
+- [ ] Write files to working directory
+
+#### Tester Agent (`scripts/pb-test.ts`)
+- [ ] Run unit tests and E2E tests
+- [ ] On failures, use `agents/tester.prompt.md` to generate fixes
+- [ ] Iterate until tests pass or max attempts reached
+
+#### Packager Agent (enhance existing `pb-move.ts` and `pb-build-tgz.ts`)
+- [ ] Use `agents/packager.prompt.md` for validation
+- [ ] Ensure proper package.json generation
+- [ ] Verify exports and TypeScript declarations
+
+#### Verifier Agent (enhance existing `pb-spinup-integration.ts`)
+- [ ] Use `agents/verifier.prompt.md` for smoke test generation
+- [ ] Validate external installation works correctly
+
+### 3. GitHub Actions Integration
+- [ ] Update `.github/workflows/package-builder.yml` to use real LLM agents
+- [ ] Add `OPENAI_API_KEY` as repository secret
+- [ ] Replace placeholder echo statements with actual script calls
+- [ ] Add proper error handling and retry logic
+
+### 4. CLI Interface
+- [ ] Create main entry point (`scripts/pb-generate.ts`)
+- [ ] Accept feature requests via CLI arguments or file input
+- [ ] Orchestrate the full 5-agent pipeline
+- [ ] Provide progress feedback and error reporting
+
+### 5. Configuration & Error Handling
+- [ ] Add model configuration options (temperature, max tokens, etc.)
+- [ ] Implement retry logic for API failures
+- [ ] Add cost tracking and usage monitoring
+- [ ] Create validation for LLM outputs
+
+## Example Usage
+
+```bash
+# Generate a new package using LLM pipeline
+npm run generate -- svg-editor \
+  --description "Tiny SVG DOM manipulation helpers for UI" \
+  --keywords "svg,dom,ui" \
+  --runtime "browser"
+
+# Or from a feature request file
+npm run generate -- --from-file feature-request.md
+```
+
+## Technical Considerations
+
+### Environment Variables
+- `OPENAI_API_KEY` - Required for API access
+- `OPENAI_MODEL` - Optional, defaults to "gpt-4"
+- `OPENAI_MAX_TOKENS` - Optional, defaults to 4000
+- `OPENAI_TEMPERATURE` - Optional, defaults to 0.1 (for consistency)
+
+### Dependencies to Add
+```json
+{
+  "dependencies": {
+    "openai": "^4.0.0"
+  }
+}
+```
+
+### File Structure Changes
+```
+scripts/
+├── llm/
+│   ├── client.ts           # OpenAI client wrapper
+│   ├── prompt-builder.ts   # Template processing
+│   └── validators.ts       # Output validation
+├── pb-generate.ts          # Main orchestrator
+├── pb-plan.ts             # Planner agent
+├── pb-implement.ts        # Implementer agent
+├── pb-test.ts             # Tester agent
+└── (existing files...)
+```
+
+## Acceptance Criteria
+- [ ] Can generate a complete, working package from a simple feature description
+- [ ] All 5 agents successfully integrate with OpenAI API
+- [ ] GitHub Actions workflow runs end-to-end with real LLM calls
+- [ ] Generated packages pass all quality gates (tests, types, exports)
+- [ ] Proper error handling and retry logic for API failures
+- [ ] Cost-effective usage with appropriate token limits
+
+## Testing Strategy
+1. **Unit Tests**: Mock OpenAI responses to test agent logic
+2. **Integration Tests**: Use real API calls with simple test cases
+3. **E2E Tests**: Generate actual packages and verify they work
+4. **Cost Testing**: Monitor token usage and optimize prompts
+
+## Success Metrics
+- Successfully generate at least 3 different types of packages (DOM utilities, data helpers, UI components)
+- 90%+ success rate on package generation
+- Generated packages pass all existing quality gates
+- Average generation time under 5 minutes
+
+## Related Files
+- `agents/planner.prompt.md` - Existing prompt template
+- `agents/implementer.prompt.md` - Existing prompt template  
+- `agents/tester.prompt.md` - Existing prompt template
+- `agents/packager.prompt.md` - Existing prompt template
+- `agents/verifier.prompt.md` - Existing prompt template
+- `.github/workflows/package-builder.yml` - GitHub Actions workflow
+
+## Priority
+High - This is the core missing piece to make the package-builder fully functional as intended.
+
+---
+
+*Note: The existing architecture and prompt templates are already well-designed for this integration. This issue focuses on connecting the OpenAI API to the existing framework.*


### PR DESCRIPTION
- Create externalize-package.yml workflow for CI-based externalization
- Add comprehensive documentation in docs/EXTERNALIZATION.md
- Update README with GitHub Actions workflow instructions
- Support workflow_dispatch with configurable parameters
- Include dry-run mode for previewing changes
- Auto-configure NPM_TOKEN secret on new repositories
- Generate detailed workflow summaries and reports

This allows externalizing packages through GitHub UI without requiring local GitHub CLI installation or authentication.