### PR TITLE
fix: configure git user identity before committing in workflow

### DIFF
--- a/scripts/pb-externalize-copy.ts
+++ b/scripts/pb-externalize-copy.ts
@@ -304,9 +304,17 @@ function main() {
   if (dryRun) {
     console.log("[dryRun] Skipping commit/push");
   } else {
+    // Configure git user identity for the commit
+    sh(`git -C "${tmp}" config user.name "github-actions[bot]"`);
+    sh(`git -C "${tmp}" config user.email "github-actions[bot]@users.noreply.github.com"`);
+
     sh(`git -C "${tmp}" add .`);
     // allow empty commit to be no-op
-    try { sh(`git -C "${tmp}" commit -m "chore: initial import from ${pkgPath}"`); } catch {}
+    try {
+      sh(`git -C "${tmp}" commit -m "chore: initial import from ${pkgPath}"`);
+    } catch (err) {
+      console.log("   ℹ️  No changes to commit (repository may already have content)");
+    }
     sh(`git -C "${tmp}" push origin HEAD:main`);
   }
 


### PR DESCRIPTION
- Set git user.name and user.email before creating commits
- Use github-actions[bot] identity for automated commits
- Improve error handling for empty commits
- Add informative message when no changes to commit

This fixes 'Author identity unknown' error in GitHub Actions runners where git user identity is not configured by default.