### PR TITLE
fix: use publicRemote in final output and add success message

### DIFF
--- a/scripts/pb-externalize-copy.ts
+++ b/scripts/pb-externalize-copy.ts
@@ -347,7 +347,13 @@ function main() {
   }
 
   // 7) Output machine-readable result for the LLM runner
-  console.log(JSON.stringify({ repo: remote, method: "copy", ok: true }));
+  console.log(JSON.stringify({ repo: publicRemote, method: "copy", ok: true }));
+  console.log("\n✅ Externalization complete!");
+  console.log(`   Repository: https://github.com/${org}/${newRepo}`);
+  console.log(`   Next steps:`);
+  console.log(`   1. Visit the repository to verify files`);
+  console.log(`   2. Create a release: npm version patch && git push --follow-tags`);
+  console.log(`   3. GitHub Actions will automatically publish to npm`);
 }
 
 main();


### PR DESCRIPTION
- Fix ReferenceError for undefined 'remote' variable
- Use publicRemote (clean URL) in final JSON output
- Add user-friendly success message with next steps
- Display repository URL and publishing instructions