### PR TITLE
feat(#127): Add build step to copy ADF file to public folder for runtime access

### DIFF
--- a/packages/repo-dashboard/package.json
+++ b/packages/repo-dashboard/package.json
@@ -43,9 +43,10 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "npm run build:cli && npm run build:web",
+    "build": "npm run copy:adf && npm run build:cli && npm run build:web",
     "build:cli": "tsc -p tsconfig.build.json",
     "build:web": "vite build",
+    "copy:adf": "node -e \"const fs = require('fs'); const path = require('path'); const srcDir = path.join(__dirname, 'docs'); const destDir = path.join(__dirname, 'dist', 'public', 'adf'); if (!fs.existsSync(destDir)) { fs.mkdirSync(destDir, { recursive: true }); } fs.copyFileSync(path.join(srcDir, 'renderx-plugins-demo-adf.json'), path.join(destDir, 'renderx-plugins-demo-adf.json')); console.log('✅ ADF file copied to dist/public/adf/');\"",
     "ci": "npm run test && npm run build",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:web\"",
     "dev:server": "tsx watch src/bin/server.ts",


### PR DESCRIPTION
## Summary
Implements GitHub Issue #127: "Add build step to copy ADF file to public folder for runtime access"

## Problem
The Architecture Definition File (ADF) located at `packages/repo-dashboard/docs/renderx-plugins-demo-adf.json` is not available at runtime in the built application. This causes the InsightsAnalyzer and other services to fail when they need to access the ADF.

## Solution
Implemented a three-tier fallback strategy:

1. **Local Endpoint (Primary)**: Express serves the ADF from `dist/public/adf/` at runtime
2. **GitHub API (Secondary)**: Falls back to fetching from GitHub if local endpoint fails
3. **Mock Data (Tertiary)**: Uses mock data as final fallback for resilience

## Changes Made

### 1. Build Process (`package.json`)
- Added `copy:adf` script that copies the ADF file from `docs/` to `dist/public/adf/` during build
- Updated build script to run: `npm run copy:adf && npm run build:cli && npm run build:web`

### 2. ADF Fetcher Service (`src/services/adf-fetcher.ts`)
- Updated `fetchADF()` method with three-tier fallback logic
- Added `fetchFromLocalEndpoint()` private method to fetch from local Express endpoint
- Added `fetchFromGitHub()` private method for GitHub API fallback
- Added `getMockADF()` private method for final fallback
- Implemented 1-hour TTL caching to reduce API calls

### 3. Tests (`test/services/adf-fetcher.test.ts`)
- Added test: "should fetch ADF from local endpoint first"
- Added test: "should fall back to GitHub API when local endpoint fails"
- Added test: "should fall back to mock data when both local and GitHub fail"
- Updated existing cache test to work with new fallback logic

## Testing
- All 582 tests pass ✅
- Build completes successfully ✅
- ADF file is correctly copied to `dist/public/adf/` during build ✅

## Related Issue
Closes #127

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author